### PR TITLE
Port Si5351 driver to Pico SDK I2C APIs

### DIFF
--- a/Wire.cpp
+++ b/Wire.cpp
@@ -28,7 +28,10 @@ void WireClass::beginTransmission(uint8_t address) {
 
 uint8_t WireClass::endTransmission() {
     int ret = i2c_write_blocking(i2cPort, txAddress, txBuffer, txLength, false);
-    return (ret < 0) ? 4 : 0; // 0 = success, 4 = error (like Arduino Wire)
+    if (ret < 0 || ret != txLength) {
+        return 4;
+    }
+    return 0; // 0 = success, 4 = error (like Arduino Wire)
 }
 
 void WireClass::write(uint8_t data) {

--- a/si5351.h
+++ b/si5351.h
@@ -29,8 +29,8 @@
 #ifndef SI5351_H_
 #define SI5351_H_
 
-#include "Arduino.h"
-#include "Wire.h"
+#include "hardware/i2c.h"
+#include "pico/types.h"
 #include <stdint.h>
 
 /* Define definitions */
@@ -279,7 +279,9 @@ struct Si5351IntStatus
 class Si5351
 {
 public:
-  Si5351(uint8_t i2c_addr = SI5351_BUS_BASE_ADDR);
+  Si5351(i2c_inst_t *i2c = i2c0, uint8_t i2c_addr = SI5351_BUS_BASE_ADDR,
+         bool manage_bus = false, uint sda_pin = 0, uint scl_pin = 1,
+         uint32_t i2c_baud = 100000);
 	bool init(uint8_t, uint32_t, int32_t);
 	void reset(void);
 	uint8_t set_freq(uint64_t, enum si5351_clock);
@@ -318,15 +320,20 @@ public:
   enum si5351_pll_input pllb_ref_osc;
 	uint32_t xtal_freq[2];
 private:
-	uint64_t pll_calc(enum si5351_pll, uint64_t, struct Si5351RegSet *, int32_t, uint8_t);
-	uint64_t multisynth_calc(uint64_t, uint64_t, struct Si5351RegSet *);
-	uint64_t multisynth67_calc(uint64_t, uint64_t, struct Si5351RegSet *);
-	void update_sys_status(struct Si5351Status *);
-	void update_int_status(struct Si5351IntStatus *);
-	void ms_div(enum si5351_clock, uint8_t, uint8_t);
-	uint8_t select_r_div(uint64_t *);
-	uint8_t select_r_div_ms67(uint64_t *);
-	int32_t ref_correction[2];
+        uint64_t pll_calc(enum si5351_pll, uint64_t, struct Si5351RegSet *, int32_t, uint8_t);
+        uint64_t multisynth_calc(uint64_t, uint64_t, struct Si5351RegSet *);
+        uint64_t multisynth67_calc(uint64_t, uint64_t, struct Si5351RegSet *);
+        void update_sys_status(struct Si5351Status *);
+        void update_int_status(struct Si5351IntStatus *);
+        void ms_div(enum si5351_clock, uint8_t, uint8_t);
+        uint8_t select_r_div(uint64_t *);
+        uint8_t select_r_div_ms67(uint64_t *);
+        int32_t ref_correction[2];
+  i2c_inst_t *i2c_port;
+  uint sda_pin;
+  uint scl_pin;
+  uint32_t i2c_baudrate;
+  bool manage_i2c_bus;
   uint8_t clkin_div;
   uint8_t i2c_bus_addr;
   bool clk_first_set[8];

--- a/si5351_calibration.cpp
+++ b/si5351_calibration.cpp
@@ -4,10 +4,10 @@
 #include "pico/stdlib.h"
 #include "pico/stdio_usb.h"
 
+#include "hardware/i2c.h"
 #include "si5351.h"
-#include "Wire.h"
 
-static Si5351 si5351;
+static Si5351 si5351(i2c0, SI5351_BUS_BASE_ADDR, true, 16, 17, 100000);
 
 static int32_t cal_factor = 0;
 static int32_t old_cal = 0;


### PR DESCRIPTION
## Summary
- replace the Arduino Wire dependency with Pico SDK i2c usage, storing the target bus and optional configuration in the Si5351 class
- update the Si5351 initialisation path and register helpers to run through i2c_write_blocking/i2c_read_blocking transactions
- refresh the calibration utility and Wire shim so they pass the i2c instance and interpret Pico SDK error semantics correctly

## Testing
- g++ -std=c++17 -c si5351.cpp *(fails: Pico SDK headers are unavailable in the container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d69adf38b883288c9d0d12df29f5b0